### PR TITLE
Do not force developers to use a specific Ruby.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ doc/
 
 #yardstick report
 measurements/report.txt
+
+# Automatic Ruby switching
+.ruby-version


### PR DESCRIPTION
We do not declare a specific Ruby version and/or implementation as the
mainstrea, so if people want to do automatic switching, they're free to use
whatever they want and Hexp should work anyway.
