### PR TITLE
Rename `Hexp::Node::Selector` to `Hexp::Node::Selection`.

### DIFF
--- a/lib/hexp.rb
+++ b/lib/hexp.rb
@@ -114,7 +114,7 @@ require 'hexp/node/normalize'
 require 'hexp/node/domize'
 require 'hexp/node/pp'
 require 'hexp/node/rewriter'
-require 'hexp/node/selector'
+require 'hexp/node/selection'
 require 'hexp/node/css_selection'
 
 require 'hexp/text_node'

--- a/lib/hexp/node.rb
+++ b/lib/hexp/node.rb
@@ -259,7 +259,7 @@ module Hexp
       if css_selector
         CssSelection.new(self, css_selector).each(&block)
       else
-        Selector.new(self, block)
+        Selection.new(self, block)
       end
     end
 

--- a/lib/hexp/node/css_selection.rb
+++ b/lib/hexp/node/css_selection.rb
@@ -32,7 +32,7 @@ module Hexp
     #     p a.text
     #   end
     #
-    class CssSelection < Selector
+    class CssSelection < Selection
       include Enumerable
 
       # Create a new CssSelection based on a root node and a selector

--- a/lib/hexp/node/selection.rb
+++ b/lib/hexp/node/selection.rb
@@ -1,6 +1,6 @@
 module Hexp
   class Node
-    # Select nodes from a Hexp tree
+    # Subset of nodes from a Hexp tree
     #
     # This is what is backing the {Hexp::Node#select} method. It serves a double
     # purpose. At it's core it's an Enumerable for iterating over nodes that
@@ -17,10 +17,11 @@ module Hexp
     #   # stick all links inside a <span class="link> ... </span>
     #   hexp.select {|el| el.tag == 'a' }.wrap(:span, class: 'link')
     #
-    class Selector
+    class Selection
       include Enumerable
 
-      # Initialize a selector with the root node, and the selection block
+      # Initialize a selection with the root node, and the selection block used
+      # as the filtering criterion
       #
       # @param [Hexp::Node] node
       #   The root of the tree to select in

--- a/lib/hexp/text_node.rb
+++ b/lib/hexp/text_node.rb
@@ -140,7 +140,7 @@ module Hexp
     end
 
     def select(&block)
-      Node::Selector.new(self, block)
+      Node::Selection.new(self, block)
     end
   end
 end

--- a/spec/unit/hexp/node/selection_spec.rb
+++ b/spec/unit/hexp/node/selection_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe Hexp::Node::Selector do
-  subject(:selector) { Hexp::Node::Selector.new(hexp, block) }
+describe Hexp::Node::Selection do
+  subject(:selection) { Hexp::Node::Selection.new(hexp, block) }
   let(:yielded_elements) { [] }
   let(:block) { proc {|el| yielded_elements << el } }
   let(:hexp) { H[:div, [[:span]]] }
@@ -10,7 +10,7 @@ describe Hexp::Node::Selector do
     let(:block) { proc {|el| el.tag == :span} }
 
     it 'should enumerate elements for which the block returns trueish' do
-      expect(selector.to_a).to eq [H[:span]]
+      expect(selection.to_a).to eq [H[:span]]
     end
   end
 
@@ -18,7 +18,7 @@ describe Hexp::Node::Selector do
     let(:block) { proc {|el| el.tag == :span} }
 
     it 'should perform them on elements that match' do
-      expect(selector.attr('class', 'matched').to_hexp).to eq(
+      expect(selection.attr('class', 'matched').to_hexp).to eq(
         H[:div, [[:span, {class: 'matched'}]]]
       )
     end
@@ -28,7 +28,7 @@ describe Hexp::Node::Selector do
       let(:block) { proc {|el| el.tag == :a} }
 
       it 'should be able to wrap element' do
-        expect(selector.wrap(:li).to_hexp).to eq(
+        expect(selection.wrap(:li).to_hexp).to eq(
            H[:ul, [[:li, H[:a, href: 'foo']], [:li, H[:a, href: 'bar']]]]
         )
       end
@@ -39,7 +39,7 @@ describe Hexp::Node::Selector do
       let(:block) { proc {|el| el.tag == :a} }
 
       it 'should work on matching elements, and skip the rest' do
-        expect(selector.rewrite{ H[:br] }.to_hexp).to eq H[:ul, [[:br], [:span]]]
+        expect(selection.rewrite{ H[:br] }.to_hexp).to eq H[:ul, [[:br], [:span]]]
       end
     end
   end
@@ -49,12 +49,12 @@ describe Hexp::Node::Selector do
 
     it 'should be lazy' do
       expect(block).to_not receive(:call)
-      selector
+      selection
     end
 
     it 'should yield the root element when realized' do
       expect(block).to receive(:call).once.with(H[:div])
-      selector.each {}
+      selection.each {}
     end
   end
 
@@ -65,7 +65,7 @@ describe Hexp::Node::Selector do
           [:span, "world"]]]}
 
     it 'should traverse the whole tree once, depth-first' do
-      selector.each {}
+      selection.each {}
       expect(yielded_elements).to eq [
         Hexp::TextNode.new("hello"),
         H[:span, "hello"],


### PR DESCRIPTION
Closes #11.
