### PR TITLE
Markaby, not Hpricot

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ gem 'hexp', require: 'hexp-rails'
 
 ## Builder
 
-If you like the Builder syntax available in other gems like Builder and Hpricot, you can use `Hexp.build` to achieve the same
+If you like the Builder syntax available in other gems like Builder and Markaby, you can use `Hexp.build` to achieve the same
 
 ``` ruby
 Hexp.build do


### PR DESCRIPTION
I think there's a tiny mixup in the README: [Hpricot](https://github.com/hpricot/hpricot) is an XML Parser, [markaby](https://github.com/whymirror/markaby) is an HTML builder (with an API that is very close to the one in the example below).
